### PR TITLE
Sync devtools and bump backports to [ ~> 3.0, >= 3.0.3 ]

### DIFF
--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -2,26 +2,25 @@
 
 group :development do
   gem 'rake',  '~> 10.0.3'
-  gem 'rspec', '~> 2.12.0'
-  gem 'yard',  '~> 0.8.4.1'
+  gem 'rspec', '~> 2.13.0'
+  gem 'yard',  '~> 0.8.5'
 end
 
 group :yard do
-  gem 'redcarpet', '~> 2.2.2', :platforms => [ :mri, :rbx ]
+  gem 'kramdown', '~> 0.14.2'
 end
 
 group :guard do
   gem 'guard',         '~> 1.6.2'
   gem 'guard-bundler', '~> 1.0.0'
-  gem 'guard-rspec',   '~> 2.3.3'
+  gem 'guard-rspec',   '~> 2.4.1'
 
   # file system change event handling
   gem 'rb-fchange', '~> 0.0.6', :require => false
   gem 'rb-fsevent', '~> 0.9.3', :require => false
   gem 'rb-inotify', '~> 0.9.0', :require => false
 
-  # Remove this one https://github.com/guard/listen/pull/78 is released
-  gem 'listen', '~> 0.7.2', :git => 'https://github.com/guard/listen.git'
+  gem 'listen', '~> 0.7.3'
 
   # notification handling
   gem 'libnotify',               '~> 0.8.0', :require => false
@@ -30,11 +29,11 @@ group :guard do
 end
 
 group :metrics do
-  gem 'flay',      '~> 1.4.3'
-  gem 'flog',      '~> 2.5.3'
-  gem 'reek',      '~> 1.2.13', :git => 'https://github.com/troessner/reek.git', :ref => 'ef77fcecaa21c9ebcbe4d9a79d41b0e70196bf18'
-  gem 'roodi',     '~> 2.2.0'
-  gem 'yardstick', '~> 0.9.2'
+  gem 'flay',            '~> 2.1.0'
+  gem 'flog',            '~> 3.2.2'
+  gem 'reek',            '~> 1.3.1'
+  gem 'metric_fu-roodi', '~> 2.2.1'
+  gem 'yardstick',       '~> 0.9.3', :git => 'https://github.com/dkubb/yardstick.git'
 
   platforms :ruby_18, :ruby_19 do
     # this indirectly depends on ffi which does not build on ruby-head
@@ -42,7 +41,7 @@ group :metrics do
   end
 
   platforms :mri_19, :rbx do
-#    gem 'mutant', '~> 0.2.16'
+    gem 'mutant', '~> 0.2.17'
   end
 
   platforms :mri_19 do

--- a/coercible.gemspec
+++ b/coercible.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'backports',           '~> 2.8'
+  gem.add_dependency 'backports',           [ '~> 3.0', '>= 3.0.3' ]
   gem.add_dependency 'descendants_tracker', '~> 0.0.1'
 end


### PR DESCRIPTION
This will only allow bundle install to complete
once mutant is bumped too, which will happen soon.
