### PR TITLE
Raise an exception if the coercion not supported

### DIFF
--- a/lib/coercible/coercer/object.rb
+++ b/lib/coercible/coercer/object.rb
@@ -76,7 +76,7 @@ module Coercible
       #
       # @api public
       def to_hash(value)
-        coerce_with_method(value, :to_hash)
+        coerce_with_method(value, :to_hash, __method__)
       end
 
       # Create a String from the Object if possible
@@ -96,7 +96,7 @@ module Coercible
       #
       # @api public
       def to_string(value)
-        coerce_with_method(value, :to_str)
+        coerce_with_method(value, :to_str, __method__)
       end
 
       # Create an Integer from the Object if possible
@@ -116,7 +116,7 @@ module Coercible
       #
       # @api public
       def to_integer(value)
-        coerce_with_method(value, :to_int)
+        coerce_with_method(value, :to_int, __method__)
       end
 
       # Return if the value was successfuly coerced
@@ -168,8 +168,8 @@ module Coercible
       # @return [Object]
       #
       # @api private
-      def coerce_with_method(value, method)
-        value.respond_to?(method) ? value.public_send(method) : value
+      def coerce_with_method(value, method, ref_method)
+        value.respond_to?(method) ? value.public_send(method) : raise_unsupported_coercion(value, ref_method)
       end
 
     end # class Object

--- a/lib/coercible/coercer/string.rb
+++ b/lib/coercible/coercer/string.rb
@@ -159,9 +159,10 @@ module Coercible
         else
           # coerce to a Float first to evaluate scientific notation (if any)
           # that may change the integer part, then convert to an integer
-          coerced = to_float(value)
-          ::Float === coerced ? coerced.to_i : coerced
+          to_float(value).to_i
         end
+      rescue UnsupportedCoercion
+        raise_unsupported_coercion(value, __method__)
       end
 
       # Coerce value to float
@@ -176,6 +177,8 @@ module Coercible
       # @api public
       def to_float(value)
         to_numeric(value, :to_f)
+      rescue UnsupportedCoercion
+        raise_unsupported_coercion(value, __method__)
       end
 
       # Coerce value to decimal
@@ -190,6 +193,8 @@ module Coercible
       # @api public
       def to_decimal(value)
         to_numeric(value, :to_d)
+      rescue UnsupportedCoercion
+        raise_unsupported_coercion(value, __method__)
       end
 
       private
@@ -226,7 +231,7 @@ module Coercible
         if value =~ NUMERIC_REGEXP
           $1.public_send(method)
         else
-          value
+          raise_unsupported_coercion(value, method)
         end
       end
 

--- a/lib/coercible/coercer/time_coercions.rb
+++ b/lib/coercible/coercer/time_coercions.rb
@@ -73,11 +73,10 @@ module Coercible
       #
       # @api private
       def coerce_with_method(value, method)
-        coerced = super
-        if coerced.equal?(value)
-          coercers[::String].public_send(method, to_string(value))
+        if value.respond_to?(method)
+          value.public_send(method)
         else
-          coerced
+          coercers[::String].public_send(method, to_string(value))
         end
       end
 

--- a/spec/unit/coercible/coercer/object/to_hash_spec.rb
+++ b/spec/unit/coercible/coercer/object/to_hash_spec.rb
@@ -17,6 +17,6 @@ describe Coercer::Object, '.to_hash' do
   end
 
   context 'when the value does not respond to #to_hash' do
-    it { should be(value) }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 end

--- a/spec/unit/coercible/coercer/object/to_integer_spec.rb
+++ b/spec/unit/coercible/coercer/object/to_integer_spec.rb
@@ -17,6 +17,6 @@ describe Coercer::Object, '.to_integer' do
   end
 
   context 'when the value does not respond to #to_int' do
-    it { should be(value) }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 end

--- a/spec/unit/coercible/coercer/object/to_string_spec.rb
+++ b/spec/unit/coercible/coercer/object/to_string_spec.rb
@@ -17,6 +17,6 @@ describe Coercer::Object, '.to_string' do
   end
 
   context 'when the value does not respond to #to_str' do
-    it { should be(value) }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 end

--- a/spec/unit/coercible/coercer/string/to_decimal_spec.rb
+++ b/spec/unit/coercible/coercer/string/to_decimal_spec.rb
@@ -42,6 +42,6 @@ describe Coercer::String, '.to_decimal' do
   context 'with an invalid decimal string' do
     let(:string) { 'non-decimal' }
 
-    it { should equal(string) }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 end

--- a/spec/unit/coercible/coercer/string/to_float_spec.rb
+++ b/spec/unit/coercible/coercer/string/to_float_spec.rb
@@ -45,13 +45,12 @@ describe Coercer::String, '.to_float' do
   context 'with an invalid float string' do
     let(:string) { 'non-float' }
 
-    it { should equal(string) }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 
   context 'string starts with e' do
     let(:string) { 'e1' }
 
-    # In further version it will raise exception
-    it { should == 'e1' }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 end

--- a/spec/unit/coercible/coercer/string/to_integer_spec.rb
+++ b/spec/unit/coercible/coercer/string/to_integer_spec.rb
@@ -50,7 +50,7 @@ describe Coercer::String, '.to_integer' do
   context 'with an invalid integer string' do
     let(:string) { 'non-integer' }
 
-    it { should equal(string) }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 
   context 'when integer string is big' do
@@ -62,7 +62,6 @@ describe Coercer::String, '.to_integer' do
   context 'string starts with e' do
     let(:string) { 'e1' }
 
-    # In further version it will raise exception
-    it { should == 'e1' }
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
   end
 end


### PR DESCRIPTION
```
coercer[String].to_integer('a')
Coercible::UnsupportedCoercion: Coercible::Coercer::String#to_integer doesn't know how to coerce "a"
```
