### PR TITLE
1.8.7 out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ before_install: gem install bundler
 bundler_args: --without guard metrics
 script: "bundle exec rake spec"
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
   - rbx-19mode
-  - ree
   - jruby-head
 
 notifications:

--- a/Gemfile.devtools
+++ b/Gemfile.devtools
@@ -29,7 +29,6 @@ group :guard do
 end
 
 group :metrics do
-  gem 'backports',       '~> 3.0', '>= 3.1.0'
   gem 'flay',            '~> 2.1.0'
   gem 'flog',            '~> 3.2.2'
   gem 'reek',            '~> 1.3.1', :git => 'https://github.com/troessner/reek.git'

--- a/coercible.gemspec
+++ b/coercible.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'backports',           [ '~> 3.0', '>= 3.1.0' ]
   gem.add_dependency 'descendants_tracker', '~> 0.0.1'
 end

--- a/lib/coercible.rb
+++ b/lib/coercible.rb
@@ -22,7 +22,6 @@ require 'time'
 require 'bigdecimal'
 require 'bigdecimal/util'
 require 'set'
-require 'backports'
 
 require 'descendants_tracker'
 require 'support/options'


### PR DESCRIPTION
Hi,

According to discussion under https://github.com/solnic/virtus/pull/168 I think it's about time to drop 1.8.7 (along with backports) from coercible too. Please let me know if this is something you want to do now and if there are any possible issues with this change.
If it's fine I will try and remove 1.8.7 support from other projects too (namely adamantium and mutant) so that backports can be dropped.
