### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/coercible.gemspec
+++ b/coercible.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Powerful, flexible and configurable coercion library. And nothing more.}
   gem.summary       = gem.description
   gem.homepage      = "https://github.com/solnic/coercible"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
