### PR TITLE
Performance

### DIFF
--- a/lib/coercible/coercer/object.rb
+++ b/lib/coercible/coercer/object.rb
@@ -9,7 +9,7 @@ module Coercible
 
       primitive ::Object
 
-      COERCION_METHOD_REGEXP = /\Ato_/.freeze
+      COERCION_METHOD_MARKER = "to_".freeze
 
       # Return coercers object
       #
@@ -161,7 +161,7 @@ module Coercible
       #
       # @api private
       def method_missing(method, *args)
-        if method.to_s =~ COERCION_METHOD_REGEXP && args.size == 1
+        if method.to_s.start_with?(COERCION_METHOD_MARKER) && args.size == 1
           args.first
         else
           super

--- a/lib/coercible/coercer/string.rb
+++ b/lib/coercible/coercer/string.rb
@@ -154,8 +154,10 @@ module Coercible
       #
       # @api public
       def to_integer(value)
-        if value =~ /\A#{INTEGER_REGEXP}\z/
-          value.to_i
+        i = value.to_i
+
+        if i.to_s == value
+          i
         else
           # coerce to a Float first to evaluate scientific notation (if any)
           # that may change the integer part, then convert to an integer


### PR DESCRIPTION
Some small performance enhancements.

coercible at `performance` branch:

```
Comparison:
Virtus: integer values for integer attributes        :    20948.6 i/s
Virtus: string values for integer attributes         :    18220.3 i/s - 1.15x slower
Virtus: string values for whatever attributes        :    18067.7 i/s - 1.16x slower
Virtus: without values                               :     9618.0 i/s - 2.18x slower
```

coercible at `master` branch:
```
Comparison:
Virtus: integer values for integer attributes        :    21541.2 i/s
Virtus: string values for whatever attributes        :    13354.4 i/s - 1.61x slower
Virtus: without values                               :    10314.2 i/s - 2.09x slower
Virtus: string values for integer attributes         :     3165.7 i/s - 6.80x slower
```

- [x] Specs pass
```
Finished in 0.28534 seconds
396 examples, 0 failures
```

Benchmark code at:
https://gist.github.com/tb0yd/79bc56683748605cff96

This benchmark is very simple & does not represent a realistic usage of Virtus. But the numbers are encouraging