### PR TITLE
Add Object#to_symbol coercion

### DIFF
--- a/lib/coercible/coercer/object.rb
+++ b/lib/coercible/coercer/object.rb
@@ -122,6 +122,35 @@ module Coercible
         coerce_with_method(value, :to_int, __method__)
       end
 
+      # Create a Symbol from the Object if possible
+      #
+      # @example with a coercible object
+      #
+      #   Foo = Class.new do
+      #     def to_sym
+      #       :foo
+      #     end
+      #   end
+      #
+      #   value = Foo.new
+      #
+      #   coercer[Object].to_symbol(value)  # => :foo
+      #
+      # @example with an object that is not coercible
+      #   coercer[Object].to_symbol(value)  # => value
+      #
+      # @param [#to_sym, Object] value
+      #
+      # @return [Symbol]
+      #   returns a Symbol when the object can be coerced
+      # @return [Object]
+      #   returns the value when the object cannot be coerced
+      #
+      # @api public
+      def to_symbol(value)
+        coerce_with_method(value, :to_sym, __method__)
+      end
+
       # Return if the value was successfuly coerced
       #
       # @example when coercion was successful

--- a/spec/unit/coercible/coercer/object/to_symbol_spec.rb
+++ b/spec/unit/coercible/coercer/object/to_symbol_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Coercer::Object, '.to_symbol' do
+  subject { object.to_symbol(value) }
+
+  let(:object) { described_class.new }
+  let(:value)  { double('value')   }
+
+  context 'when the value responds to #to_sym' do
+    let(:coerced) { double('coerced') }
+
+    before do
+      expect(value).to receive(:to_sym).and_return(coerced)
+    end
+
+    it { is_expected.to be(coerced) }
+  end
+
+  context 'when the value does not respond to #to_sym' do
+    specify { expect { subject }.to raise_error(UnsupportedCoercion) }
+  end
+end


### PR DESCRIPTION
I have just came across a problem in which I need to coerce an `Object` subclass into a `Symbol`. Is there any reason for not having a `#to_symbol` coerce method? 

Thank you!
