### PR TITLE
Coercer::Object - dynamically define to_* method inside method_missing

### DIFF
--- a/lib/coercible/coercer/object.rb
+++ b/lib/coercible/coercer/object.rb
@@ -162,6 +162,10 @@ module Coercible
       # @api private
       def method_missing(method, *args)
         if method.to_s =~ COERCION_METHOD_REGEXP && args.size == 1
+          self.class.send(:define_method, method) do |value|
+            value
+          end
+
           args.first
         else
           super


### PR DESCRIPTION
Benchmark code: https://gist.github.com/kml/0fb1588fc1b6ba4c60fa
While testing on JRuby I'm gaining at least x2 improvement thanks
to defining method.

Other solution (maybe even better) could be to staticaly define methods like:

``` ruby
module Coercible
  class Coercer
    class Object
      def to_object(value)
        value
      end

      def to_boolean(value)
        value
      end
    end
  end
end
```
