### PR TITLE
Improve unsupported coercion performance by optionally caching error

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ coercer[String].to_boolean('nope') # => false
 Note that at the moment only Integer and String are configurable. More configurable
 coercers will be added later whenever we find good usecases.
 
+### Reduce exception overhead using cached errors
+
+As identified in <https://github.com/solnic/coercible/issues/16> and <https://github.com/jruby/jruby/issues/4540>, coercible's use of errors to signal unsupported coercions has a measurable impact on performance, especially when using JRuby.
+
+As a workaround for this, whenever the environment variable `COERCIBLE_CACHE_UNSUPPORTED_COERCION_ERROR` is set to `1`, coercible will reuse a cached error, rather than raising a new error every time. This improves the performance, at the cost of a useless backtrace --- all `UnsupportedCoercion` errors will share the same dummy backtrace.
+
 ## Contributing
 
 1. Fork it

--- a/benchmarks/benchmark_cached_unsupported_coercion_error.rb
+++ b/benchmarks/benchmark_cached_unsupported_coercion_error.rb
@@ -1,0 +1,41 @@
+require 'benchmark/ips'
+require 'coercible'
+
+COERCER = Coercible::Coercer.new
+
+Benchmark.ips do |benchmark|
+  benchmark.time = 30
+  benchmark.warmup = 30
+
+  benchmark.report(:cached_unsupported_coercion_error) do |times|
+    ENV['COERCIBLE_CACHE_UNSUPPORTED_COERCION_ERROR'] = '1'
+
+    i = 0
+    while i < times
+      begin
+        COERCER[String].to_string(nil)
+      rescue ::Coercible::UnsupportedCoercion
+        :ignore
+      end
+
+      i += 1
+    end
+  end
+
+  benchmark.report(:noncached_unsupported_coercion_error) do |times|
+    ENV['COERCIBLE_CACHE_UNSUPPORTED_COERCION_ERROR'] = nil
+
+    i = 0
+    while i < times
+      begin
+        COERCER[String].to_string(nil)
+      rescue ::Coercible::UnsupportedCoercion
+        :ignore
+      end
+
+      i += 1
+    end
+  end
+
+  benchmark.compare!
+end

--- a/coercible.gemspec
+++ b/coercible.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rspec-its', '~> 1.0'
+  gem.add_development_dependency 'benchmark-ips', '~> 2.7'
 end

--- a/lib/coercible/coercer/object.rb
+++ b/lib/coercible/coercer/object.rb
@@ -139,6 +139,19 @@ module Coercible
 
       private
 
+      def self.cache_unsupported_coercion_error
+        begin
+          raise(
+            UnsupportedCoercion,
+            "Cached UnsupportedCoercion. Disable cache with " \
+            "ENV['COERCIBLE_CACHE_UNSUPPORTED_COERCION_ERROR'] = nil to see real backtrace and error message.")
+        rescue UnsupportedCoercion => cached_exception
+          cached_exception
+        end
+      end
+
+      CACHED_UNSUPPORTED_COERCION_ERROR = cache_unsupported_coercion_error
+
       # Raise an unsupported coercion error
       #
       # @raises [UnsupportedCoercion]
@@ -147,10 +160,14 @@ module Coercible
       #
       # @api private
       def raise_unsupported_coercion(value, method)
-        raise(
-          UnsupportedCoercion,
-          "#{self.class}##{method} doesn't know how to coerce #{value.inspect}"
-        )
+        if ENV['COERCIBLE_CACHE_UNSUPPORTED_COERCION_ERROR'] == '1'
+          raise CACHED_UNSUPPORTED_COERCION_ERROR
+        else
+          raise(
+            UnsupportedCoercion,
+            "#{self.class}##{method} doesn't know how to coerce #{value.inspect}"
+          )
+        end
       end
 
       # Passthrough given value


### PR DESCRIPTION
As identified in <https://github.com/solnic/coercible/issues/16> and <https://github.com/jruby/jruby/issues/4540>, coercible's use of errors
to signal unsupported coercions has a measurable impact on performance, especially when using JRuby.

To workaround this problem, this PR adds the option (controlled by the setting the `COERCIBLE_CACHE_UNSUPPORTED_COERCION_ERROR` environment variable to `'1'`, off by default) to reuse a cached error object, rather than raising a new instance every time.
This saves a big slice of the cost of using errors, but trades it off with having a useless backtrace -- all `UnsupportedCoercion` errors will share the same backtrace.

It also includes a benchmark that can be used to measure the impact of this change. Here are some results of the benchmark on my local machine (Core i7-6500U, Ubuntu 17.04):

* `ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]`:

        cached_unsupported_coercion_error
          559.584k (± 8.3%) i/s -     16.664M in  30.057606s
        noncached_unsupported_coercion_error
          287.123k (±13.9%) i/s -      8.402M in  30.018748s

        Comparison:
          cached_unsupported_coercion_error:   559583.7 i/s
          noncached_unsupported_coercion_error:   287123.4 i/s - 1.95x  slower

* `jruby 9.1.7.0 (2.3.1) 2017-01-11 68056ae Java HotSpot(TM) 64-Bit Server VM 25.131-b11 on 1.8.0_131-b11 +indy +jit [linux-x86_64]`:

        cached_unsupported_coercion_error
          797.391k (± 9.1%) i/s -     23.619M in  29.979835s
        noncached_unsupported_coercion_error
          589.736k (± 9.0%) i/s -     17.477M in  29.996031s

        Comparison:
          cached_unsupported_coercion_error:   797390.8 i/s
          noncached_unsupported_coercion_error:   589735.9 i/s - 1.35x  slower

* `jruby 9.1.12.0 (2.3.3) 2017-06-15 33c6439 Java HotSpot(TM) 64-Bit Server VM 25.131-b11 on 1.8.0_131-b11 +indy +jit [linux-x86_64]`

        cached_unsupported_coercion_error
          843.364k (± 8.4%) i/s -     24.977M in  29.973919s
        noncached_unsupported_coercion_error
          5.757k (±10.5%) i/s -    169.785k in  30.029482s

        Comparison:
          cached_unsupported_coercion_error:   843363.9 i/s
          noncached_unsupported_coercion_error:     5757.1 i/s - 146.49x  slower

  (The difference here to 9.1.7.0 is due to the "regression" in    https://github.com/jruby/jruby/issues/4540)